### PR TITLE
build: Only git clone bazel-eclipse once (if bazel-eclipse/ directory does not yet exist)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,10 @@ gulp.task('build-plugin', (done) => {
     }
   });
 
+  if (!fs.existsSync(bazelEclipseDir)) {
+    fs.mkdirSync(bazelEclipseDir);
+  }
+
   // del.sync(bazelEclipseDir + '/**', { force: true });
   fs.rmdirSync(bazelEclipseDir, {recursive: true});
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,12 +16,16 @@ gulp.task('build-plugin', (done) => {
 
   if (!fs.existsSync(bazelEclipseDir)) {
     fs.mkdirSync(bazelEclipseDir);
+
+    // del.sync(bazelEclipseDir + '/**', { force: true });
+    fs.rmdirSync(bazelEclipseDir, { recursive: true });
+
+    cp.execSync('git clone https://github.com/salesforce/bazel-eclipse.git', {
+      cwd: __dirname,
+      stdio: [0, 1, 2],
+    });
   }
 
-  // del.sync(bazelEclipseDir + '/**', { force: true });
-  fs.rmdirSync(bazelEclipseDir, {recursive: true});
-
-  cp.execSync('git clone https://github.com/salesforce/bazel-eclipse.git', { cwd: __dirname, stdio: [0, 1, 2] });
   cp.execSync(`mvn clean package`, { cwd: bazelEclipseDir, stdio: [0, 1, 2] });
   renameTarget('com.salesforce.b2eclipse.jdt.ls');
   renameTarget('com.salesforce.bazel.eclipse.common');


### PR DESCRIPTION
@guw do you think this (look at the 2nd commit only; the 1st one is just #27) would make sense and be useful?

This is a follow-up to #23.