### PR TITLE
Build bazel-eclipse/ using ./mvnw Maven wrapper instead of mvn

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,10 @@ gulp.task('build-plugin', (done) => {
     }
   });
 
+  if (!fs.existsSync(bazelEclipseDir)) {
+    fs.mkdirSync(bazelEclipseDir);
+  }
+
   // del.sync(bazelEclipseDir + '/**', { force: true });
   fs.rmdirSync(bazelEclipseDir, {recursive: true});
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,12 +16,16 @@ gulp.task('build-plugin', (done) => {
 
   if (!fs.existsSync(bazelEclipseDir)) {
     fs.mkdirSync(bazelEclipseDir);
+
+    // del.sync(bazelEclipseDir + '/**', { force: true });
+    fs.rmdirSync(bazelEclipseDir, { recursive: true });
+
+    cp.execSync('git clone https://github.com/salesforce/bazel-eclipse.git', {
+      cwd: __dirname,
+      stdio: [0, 1, 2],
+    });
   }
 
-  // del.sync(bazelEclipseDir + '/**', { force: true });
-  fs.rmdirSync(bazelEclipseDir, {recursive: true});
-
-  cp.execSync('git clone https://github.com/salesforce/bazel-eclipse.git', { cwd: __dirname, stdio: [0, 1, 2] });
   cp.execSync(`mvn clean package`, { cwd: bazelEclipseDir, stdio: [0, 1, 2] });
   renameTarget('com.salesforce.b2eclipse.jdt.ls');
   renameTarget('com.salesforce.bazel.eclipse.common');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ gulp.task('build-plugin', (done) => {
     });
   }
 
-  cp.execSync(`mvn clean package`, { cwd: bazelEclipseDir, stdio: [0, 1, 2] });
+  cp.execSync(mvnw() + ' clean package', { cwd: bazelEclipseDir, stdio: [0, 1, 2] });
   renameTarget('com.salesforce.b2eclipse.jdt.ls');
   renameTarget('com.salesforce.bazel.eclipse.common');
   renameTarget('com.salesforce.bazel-java-sdk');


### PR DESCRIPTION
Requires https://github.com/salesforce/bazel-eclipse/pull/448, for https://github.com/salesforce/bazel-eclipse/issues/445.

Review the 3rd commit only, after having merged #28 and and #27 (or ask me to rebase this if you want to reject #28).

@guw