### PR TITLE
modify file watcher strategy for .bazelproject and BUILD files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1751,9 +1751,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.3.tgz",
-			"integrity": "sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.4.tgz",
+			"integrity": "sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==",
 			"dev": true
 		},
 		"node_modules/@types/glob": {
@@ -1829,9 +1829,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.8.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
-			"integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+			"version": "20.8.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+			"integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -1877,16 +1877,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.0.tgz",
-			"integrity": "sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz",
+			"integrity": "sha512-w0tiiRc9I4S5XSXXrMHOWgHgxbrBn1Ro+PmiYhSg2ZVdxrAJtQgzU5o2m1BfP6UOn7Vxcc6152vFjQfmZR4xEg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/type-utils": "6.9.0",
-				"@typescript-eslint/utils": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.9.1",
+				"@typescript-eslint/type-utils": "6.9.1",
+				"@typescript-eslint/utils": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -1912,15 +1912,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
-			"integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
+			"integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/typescript-estree": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.9.1",
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/typescript-estree": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1940,13 +1940,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
-			"integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
+			"integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0"
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -1957,13 +1957,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.0.tgz",
-			"integrity": "sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.1.tgz",
+			"integrity": "sha512-eh2oHaUKCK58qIeYp19F5V5TbpM52680sB4zNSz29VBQPTWIlE/hCj5P5B1AChxECe/fmZlspAWFuRniep1Skg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.9.0",
-				"@typescript-eslint/utils": "6.9.0",
+				"@typescript-eslint/typescript-estree": "6.9.1",
+				"@typescript-eslint/utils": "6.9.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -1984,9 +1984,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
-			"integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
+			"integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -1997,13 +1997,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
-			"integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
+			"integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2024,17 +2024,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.0.tgz",
-			"integrity": "sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.1.tgz",
+			"integrity": "sha512-L1T0A5nFdQrMVunpZgzqPL6y2wVreSyHhKGZryS6jrEN7bD9NplVAyMryUhXsQ4TWLnZmxc2ekar/lSGIlprCA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/typescript-estree": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.9.1",
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/typescript-estree": "6.9.1",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2049,12 +2049,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
-			"integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
+			"integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
+				"@typescript-eslint/types": "6.9.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -3741,9 +3741,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001558",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001558.tgz",
-			"integrity": "sha512-/Et7DwLqpjS47JPEcz6VnxU9PwcIdVi0ciLXRWBQdj1XFye68pSQYpV0QtPTfUKWuOaEig+/Vez2l74eDc1tPQ==",
+			"version": "1.0.30001559",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
+			"integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
 			"dev": true,
 			"funding": [
 				{
@@ -4928,9 +4928,9 @@
 			}
 		},
 		"node_modules/domain-browser": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
-			"integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
+			"integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -5082,9 +5082,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.569",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.569.tgz",
-			"integrity": "sha512-LsrJjZ0IbVy12ApW3gpYpcmHS3iRxH4bkKOW98y1/D+3cvDUWGcbzbsFinfUS8knpcZk/PG/2p/RnkMCYN7PVg==",
+			"version": "1.4.572",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.572.tgz",
+			"integrity": "sha512-RlFobl4D3ieetbnR+2EpxdzFl9h0RAJkPK3pfiwMug2nhBin2ZCsGIAJWdpNniLz43sgXam/CgipOmvTA+rUiA==",
 			"dev": true
 		},
 		"node_modules/elliptic": {
@@ -5161,9 +5161,9 @@
 			}
 		},
 		"node_modules/envinfo": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.10.0.tgz",
-			"integrity": "sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.11.0.tgz",
+			"integrity": "sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==",
 			"dev": true,
 			"bin": {
 				"envinfo": "dist/cli.js"
@@ -9153,9 +9153,9 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -13839,9 +13839,9 @@
 			}
 		},
 		"node_modules/request/node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -15244,9 +15244,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.23.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.23.0.tgz",
-			"integrity": "sha512-Iyy83LN0uX9ZZLCX4Qbu5JiHiWjOCTwrmM9InWOzVeM++KNWEsqV4YgN9U9E8AlohQ6Gs42ztczlWOG/lwDAMA==",
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
+			"integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
@@ -15746,9 +15746,9 @@
 			}
 		},
 		"node_modules/tough-cookie/node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -15776,9 +15776,9 @@
 			}
 		},
 		"node_modules/tr46/node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -16295,9 +16295,9 @@
 			}
 		},
 		"node_modules/universalify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 10.0.0"
@@ -16401,9 +16401,9 @@
 			}
 		},
 		"node_modules/uri-js/node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"

--- a/src/test/projects/small/.vscode/settings.json
+++ b/src/test/projects/small/.vscode/settings.json
@@ -11,18 +11,20 @@
 		"module1": false,
 		"module2": false,
 		"module3": false,
-		"third_party": true,
-		"bazel-bin": true,
-		"bazel-out": true,
-		"bazel-small": true,
-		"bazel-testlogs": true,
+		"third_party": false,
+		"bazel-bin": false,
+		"bazel-out": false,
+		"bazel-small": false,
+		"bazel-testlogs": false,
 		".settings": true,
-		"tools": true
+		"tools": false
 	},
-	"java.bazel.log.level": "debug",
+	"java.bazel.log.level": "trace",
+	"java.showBuildStatusOnStart.enabled": "terminal",
 	"java.debug.logLevel": "verbose",
 	"java.trace.server": "verbose",
 	"java.server.launchMode": "Standard",
+	"java.transport":"stdio",
 	"java.import.generatesMetadataFilesAtProjectRoot":false,
 	"java.autobuild.enabled": true
 }

--- a/src/test/projects/small/.vscode/settings.json
+++ b/src/test/projects/small/.vscode/settings.json
@@ -22,6 +22,7 @@
 	"java.bazel.log.level": "debug",
 	"java.debug.logLevel": "verbose",
 	"java.trace.server": "verbose",
+	"java.server.launchMode": "Standard",
 	"java.import.generatesMetadataFilesAtProjectRoot":false,
 	"java.autobuild.enabled": true
 }


### PR DESCRIPTION
- stop using filewatchers and start monitoring the state of the currently open files.
- refactor command registration logic