### PR TITLE
added bazel task runner to the explorer view

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,9 +142,49 @@
 				"command": "java.bazel.showStatus",
 				"title": "Show Bazel Build Status",
 				"category": "Bazel"
+			},
+			{
+				"command": "bazelTaskOutline.refresh",
+				"title": "Refresh Bazel Run Configs",
+				"category": "Bazel",
+				"icon": "$(sync)"
+			},
+			{
+				"command": "bazelTaskOutline.run",
+				"title": "Run Bazel Target",
+				"category": "Bazel",
+				"icon": "$(debug-start)"
+			},
+			{
+				"command": "bazelTaskOutline.kill",
+				"title": "Kill Bazel Target",
+				"category": "Bazel",
+				"icon": "$(debug-stop)"
 			}
 		],
+		"views": {
+			"explorer": [
+				{
+					"id": "bazelTaskOutline",
+					"name": "Bazel Run Targets"
+				}
+			]
+		},
 		"menus": {
+			"commandPalette": [
+				{
+					"command": "bazelTaskOutline.refresh",
+					"when": "false"
+				},
+				{
+					"command": "bazelTaskOutline.run",
+					"when": "false"
+				},
+				{
+					"command": "bazelTaskOutline.kill",
+					"when": "false"
+				}
+			],
 			"explorer/context": [
 				{
 					"command": "java.bazel.syncProjects.command",
@@ -155,6 +195,25 @@
 					"command": "java.bazel.updateClasspaths.command",
 					"when": "javaLSReady && isFileSystemResource",
 					"group": "1_javaactions@11"
+				}
+			],
+			"view/title": [
+				{
+					"command": "bazelTaskOutline.refresh",
+					"when": "view == bazelTaskOutline",
+					"group": "navigation@1"
+				}
+			],
+			"view/item/context": [
+				{
+					"command": "bazelTaskOutline.run",
+					"when": "view == bazelTaskOutline && viewItem == task",
+					"group": "inline@1"
+				},
+				{
+					"command": "bazelTaskOutline.kill",
+					"when": "view == bazelTaskOutline && viewItem == runningTask",
+					"group": "inline@2"
 				}
 			]
 		}

--- a/src/bazelTaskManager.ts
+++ b/src/bazelTaskManager.ts
@@ -1,0 +1,18 @@
+import { tasks } from 'vscode';
+import { BazelRunTarget, BazelRunTargetProvider } from "./provider/bazelRunTargetProvider";
+
+export namespace BazelTaskManager {
+	export function refreshTasks() {
+		BazelRunTargetProvider.instance.refresh();
+	}
+
+	export function runTask(bazelTarget: BazelRunTarget) {
+		bazelTarget.contextValue = 'runningTask';
+		tasks.executeTask(bazelTarget.task!);
+	}
+
+	export function killTask(bazelTarget: BazelRunTarget) {
+		bazelTarget.execution?.terminate();
+		bazelTarget.contextValue = 'task';
+	}
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -37,6 +37,10 @@ export namespace Commands {
 	export const DEBUG_LS_CMD = 'java.bazel.debug.command';
 
 	export const OPEN_BAZEL_BUILD_STATUS_CMD = 'java.bazel.showStatus';
+
+	export const BAZEL_TARGET_REFRESH = 'bazelTaskOutline.refresh';
+	export const BAZEL_TARGET_RUN = 'bazelTaskOutline.run';
+	export const BAZEL_TARGET_KILL = 'bazelTaskOutline.kill';
 }
 
 export function executeJavaLanguageServerCommand<T = unknown>(...rest: any[]): Thenable<T> {

--- a/src/provider/bazelRunTargetProvider.ts
+++ b/src/provider/bazelRunTargetProvider.ts
@@ -1,0 +1,49 @@
+import { Command, Event, EventEmitter, ProviderResult, Task, TaskExecution, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, tasks } from "vscode";
+
+export class BazelRunTargetProvider implements TreeDataProvider<BazelRunTarget> {
+
+	private static _instance: BazelRunTargetProvider;
+
+	private _onDidChangeTreeData: EventEmitter<BazelRunTarget | undefined | void> = new EventEmitter<BazelRunTarget | undefined | void>();
+	readonly onDidChangeTreeData: Event<BazelRunTarget | undefined | void> = this._onDidChangeTreeData.event;
+
+	private constructor() {}
+
+	public static get instance(): BazelRunTargetProvider {
+		if(!BazelRunTargetProvider._instance) {
+			BazelRunTargetProvider._instance = new BazelRunTargetProvider();
+		}
+		return BazelRunTargetProvider._instance;
+	}
+
+	refresh(...args: any[]): void {
+		this._onDidChangeTreeData.fire();
+	}
+
+	getTreeItem(element: BazelRunTarget): TreeItem | Thenable<TreeItem> {
+		return element;
+	}
+	getChildren(element?: BazelRunTarget | undefined): ProviderResult<BazelRunTarget[]> {
+		return tasks
+			.fetchTasks({type: 'bazel'})
+			.then(bt =>
+				bt.map(t =>
+					new BazelRunTarget(t, TreeItemCollapsibleState.None)));
+	}
+}
+
+export class BazelRunTarget extends TreeItem {
+	public readonly task: Task | undefined;
+	public readonly execution: TaskExecution | undefined;
+
+	constructor(task: Task, collapsibleState: TreeItemCollapsibleState, command?: Command){
+		super(task.name, collapsibleState);
+		this.task = task;
+		this.command = command;
+		this.execution = tasks.taskExecutions.find(e => e.task.name === this.task?.name && e.task.source === task.source);
+		this.contextValue = this.execution ? 'runningTask' : 'task';
+		if(this.execution) {
+			this.iconPath = new ThemeIcon('sync~spin');
+		}
+	}
+}

--- a/src/provider/bazelSyncStatusProvider.ts
+++ b/src/provider/bazelSyncStatusProvider.ts
@@ -1,8 +1,8 @@
 import { existsSync, lstatSync, readdirSync } from 'fs';
 import * as path from 'path';
 import { CancellationToken, Command, Event, EventEmitter, FileSystemWatcher, ProviderResult, RelativePattern, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri, window, workspace } from 'vscode';
-import { Commands, executeJavaLanguageServerCommand } from './commands';
-import { UpdateClasspathResponse } from './types';
+import { Commands, executeJavaLanguageServerCommand } from '../commands';
+import { UpdateClasspathResponse } from '../types';
 
 const SYNCED = 'synced';
 const UNSYNCED = 'unsynced';

--- a/src/provider/bazelTaskProvider.ts
+++ b/src/provider/bazelTaskProvider.ts
@@ -3,9 +3,9 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { format } from 'util';
 import { ShellExecution, Task, TaskDefinition, TaskProvider, TaskScope } from 'vscode';
-import { BazelLanguageServerTerminal } from './bazelLangaugeServerTerminal';
-import { getBazelProjectFile } from './bazelprojectparser';
-import { getWorkspaceRoot } from './util';
+import { BazelLanguageServerTerminal } from '../bazelLangaugeServerTerminal';
+import { getBazelProjectFile } from '../bazelprojectparser';
+import { getWorkspaceRoot } from '../util';
 
 const parser = new XMLParser({ignoreAttributes : false, allowBooleanAttributes: true});
 

--- a/src/test/projects/small/tools/intellij/runConfigurations/Custom_Bazel_Target.xml
+++ b/src/test/projects/small/tools/intellij/runConfigurations/Custom_Bazel_Target.xml
@@ -1,6 +1,6 @@
 <configuration default="false" name="Custom Bazel Target" type="BlazeCommandRunConfigurationType" factoryName="Bazel Command" nameIsGenerated="false">
-  <blaze-settings blaze-command="run" kind="java_binary" handler-id="BlazeJavaRunConfigurationHandlerProvider">
-    <blaze-target>//:custom-bazel-target</blaze-target>
+  <blaze-settings blaze-command="query" kind="java_binary" handler-id="BlazeJavaRunConfigurationHandlerProvider">
+    <blaze-target>//...</blaze-target>
     <blaze-user-exe-flag>-c=$PROJECT_DIR$/..</blaze-user-exe-flag>
   </blaze-settings>
   <method v="2">


### PR DESCRIPTION
Added a new view that displays all available `bazel` tasks, and allows users to execute them from that view. There is the ability to kill any running task in the view, and status is displayed via a spinner