### PR TITLE
added show .bazelproject file setting and cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
 					"default": "info",
 					"description": "Configure detailed logging (debug, warn, info, error)",
 					"scope": "window"
+				},
+				"bazel.projectview.open": {
+					"type": "boolean",
+					"default": true,
+					"description": "Open the Bazel Project View file on extension activation",
+					"scope": "window"
 				}
 			}
 		},
@@ -160,6 +166,11 @@
 				"title": "Kill Bazel Target",
 				"category": "Bazel",
 				"icon": "$(debug-stop)"
+			},
+			{
+				"command": "bazel.projectview.open",
+				"title": "Open the Bazel Project View file",
+				"category": "Bazel"
 			}
 		],
 		"views": {
@@ -183,6 +194,10 @@
 				{
 					"command": "bazelTaskOutline.kill",
 					"when": "false"
+				},
+				{
+					"command": "bazel.projectview.open",
+					"when": "isBazelWorkspaceRoot"
 				}
 			],
 			"explorer/context": [

--- a/src/bazelprojectparser.ts
+++ b/src/bazelprojectparser.ts
@@ -124,9 +124,8 @@ function removeComments(bazelProjectFileContent: string): string {
 }
 
 export async function getBazelProjectFile(): Promise<BazelProjectView> {
-	const workspaceRoot = getWorkspaceRoot();
 	try{
-		const bazelProjectFileStat = await workspace.fs.stat(Uri.parse(`${workspaceRoot}/.eclipse/.bazelproject`));
+		const bazelProjectFileStat = await workspace.fs.stat(Uri.parse(`${getWorkspaceRoot()}/.eclipse/.bazelproject`));
 		if(bazelProjectFileStat.type === FileType.File) {
 			return readBazelProject(`.eclipse/.bazelproject`);
 		}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -41,6 +41,8 @@ export namespace Commands {
 	export const BAZEL_TARGET_REFRESH = 'bazelTaskOutline.refresh';
 	export const BAZEL_TARGET_RUN = 'bazelTaskOutline.run';
 	export const BAZEL_TARGET_KILL = 'bazelTaskOutline.kill';
+
+	export const OPEN_BAZEL_PROJECT_FILE = 'bazel.projectview.open';
 }
 
 export function executeJavaLanguageServerCommand<T = unknown>(...rest: any[]): Thenable<T> {

--- a/src/provider/bazelTaskProvider.ts
+++ b/src/provider/bazelTaskProvider.ts
@@ -62,14 +62,15 @@ async function getBazelTasks(): Promise<Task[]> {
 	const bazelProjectFile = await getBazelProjectFile();
 	if((bazelProjectFile).importRunConfigurations) {
 
-		const rootPath = getWorkspaceRoot();
-		bazelProjectFile.importRunConfigurations.forEach(runConfig => {
-			try{
+		try {
+			const rootPath = getWorkspaceRoot();
+			bazelProjectFile.importRunConfigurations.forEach(runConfig => {
 				tasksDefenitions.push(getIJRunConfig(join(rootPath, runConfig)));
-			} catch(err) {
-				BazelLanguageServerTerminal.warn(`failed to convert ${runConfig}: ${format(err)}`);
-			}
-		});
+			});
+		} catch(err) {
+			BazelLanguageServerTerminal.warn(`failed to convert intellj run config: ${format(err)}`);
+		}
+
 	}
 
 	return tasksDefenitions.map((value) => new Task(value, TaskScope.Workspace, `${value.name}`, `${value.type}`, new ShellExecution(`${value.task}`), []));

--- a/src/test/projects/small/.vscode/settings.json
+++ b/src/test/projects/small/.vscode/settings.json
@@ -26,5 +26,6 @@
 	"java.server.launchMode": "Standard",
 	"java.transport":"stdio",
 	"java.import.generatesMetadataFilesAtProjectRoot":false,
-	"java.autobuild.enabled": true
+	"java.autobuild.enabled": true,
+	"bazel.projectview.open": false
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -59,7 +59,8 @@ suite('Java Language Extension - Standard', () => {
 			Commands.UPDATE_CLASSPATHS,
 			Commands.REGISTER_BAZEL_TCP_SERVER_PORT,
 			Commands.DEBUG_LS_CMD,
-			Commands.OPEN_BAZEL_BUILD_STATUS_CMD
+			Commands.OPEN_BAZEL_BUILD_STATUS_CMD,
+			Commands.OPEN_BAZEL_PROJECT_FILE
 		].sort();
 
 		const foundBazelJavaCommands = commands.filter((value) => {


### PR DESCRIPTION
- added logic to only display the `.eclipse/.bazelproject` file once after extension activation
- added a `open .bazelproject` file command 