### PR TITLE
Add clarification re. Java source level error to Troubleshooting doc

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -52,6 +52,16 @@ When troubleshooting, it can sometimes be slightly confusing which extension iss
 
 If in doubt, it is therefore recommended to temporarily _Disable in Workspace_ that other Bazel extension when debugging problems with this extension.
 
+## Java Version
+
+```java
+!ENTRY org.eclipse.jdt.ls.core 4 0 2024-01-05 12:39:25.798
+!MESSAGE Error occured while building workspace. Details:
+ message: Preview features enabled at an invalid source release level 11, preview can be enabled only at source level 21; code: 2098258; resource: /home/vorburger/git/github.com/vorburger/LearningBazel/java-one/src/main/java/ch/vorburger/learningbazel/Main.java;
+```
+
+This error (visible in `.log`) actually appears to be "harmless"; more background in [issue #74](https://github.com/salesforce/bazel-vscode-java/issues/74).
+
 ## Menus
 
 If the _Synchronize Projects with Bazel View_ and _Refresh Classpath from Bazel BUILD file_


### PR DESCRIPTION
Re. _preview features enabled at an invalid source release level 11, preview can be enabled only at source level 21_ from #74.

@guw 