### PR TITLE
added sync file watcher exclude sync feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,12 @@
 					"default": true,
 					"description": "Open the Bazel Project View file on extension activation",
 					"scope": "window"
+				},
+				"bazel.projectview.updateFileWatcherExclusion": {
+					"type": "boolean",
+					"default": true,
+					"description": "update the files.watcherExclude setting to only watch directories specified in the .bazelproject file. when enabled the window will automatically be reloaded after the change is applied",
+					"scope": "window"
 				}
 			}
 		},

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,6 +15,10 @@ export interface ExcludeConfig {
 	[x: string]: boolean;
 }
 
+export interface FileWatcherExcludeConfig {
+	[x: string]: boolean;
+}
+
 export interface ParseConfig {
 	root: string;
 	imports: string[];


### PR DESCRIPTION
For very large projects vscode can be overly greedy in it's allocation of file watchers. This feature is meant to limit the set of file watchers to only those directories derived from the `.eclipse/.bazelproject` file

<img width="459" alt="Screenshot 2024-01-12 at 9 39 03 AM" src="https://github.com/salesforce/bazel-vscode-java/assets/1170304/277b60f3-7041-42fc-a8b1-8d6ebb0643a4">
