### PR TITLE
Add more tips to Troubleshooting doc

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -69,6 +69,12 @@ The Bazel and JDT Job status is not in these log files, but visible
 on the _Terminal_ view _Bazel Build Status_ and _Java Build Status_ tabs;
 if in doubt, have a look at that as well (see also [issue #100](https://github.com/salesforce/bazel-vscode-java/issues/100)).
 
+There is a known limitation during initialization of the Java Language Server.
+While the initialization is ongoing the _Bazel Build Status_ will remain empty.
+It only starts working _after_ initialization completed.
+To work around this limitation you should configure a _static_ port for the extension to use.
+This can be done by adding `-Djava.bazel.staticProcessStreamSocket=22222` to `"java.jdt.ls.vmargs":` option in `.vscode/settings.json`.
+
 ## Extensions
 
 Please note that this _Bazel for Java_ extension (`sfdc.bazel-vscode-java`, which adds support for Bazel's **Java** rules to VSC), is technically completely independent of _[the VSC Bazel](https://marketplace.visualstudio.com/items?itemName=BazelBuild.vscode-bazel)_ extension (`BazelBuild.vscode-bazel`, which adds generic support for Bazel `BUILD` files editing, and "externally running" any Bazel targets; but specific nothing for Java).

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -67,7 +67,7 @@ in order to be able to upload as attachment to GitHub issues.)
 
 The Bazel and JDT Job status is not in these log files, but visible
 on the _Terminal_ view _Bazel Build Status_ and _Java Build Status_ tabs;
-if in doubt, have a look at that as well.
+if in doubt, have a look at that as well (see also [issue #100](https://github.com/salesforce/bazel-vscode-java/issues/100)).
 
 ## Extensions
 

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -40,6 +40,8 @@ see [issue #94](https://github.com/salesforce/bazel-vscode-java/issues/94).
 1. Close (all of) your VSC windows
 1. `killall java` (check that `jps` only shows _Jps_ itself)
 1. `cd YOURPROJECT`
+1. `rm -rf bazel-*` removes all Bazel related temporary files of course; but this should almost never be required!
+1. `rm -rf .eclipse/` removes all files configuring this extension, this normally also isn't required, but just in case
 1. `bazel build //...` must first work, obviously (double check!)
 1. `code .`
 1. Double check that the [the extension](vscode:extension/sfdc.bazel-vscode-java) is installed **and not disabled**
@@ -48,6 +50,8 @@ see [issue #94](https://github.com/salesforce/bazel-vscode-java/issues/94).
 1. Run the _Java: Show Build Job Status_ command, and wait for it to "quiet down" and everything in it to be `[Done]`
 1. Run the _Java: Synchronize Projects with Bazel Project View_ command
 1. Run the _Java: Refresh Classpath from Bazel BUILD file_ command
+
+You could also try to uninstall and reinstall the extension, to see if that helps.
 
 ## Logs
 

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -67,6 +67,10 @@ Please attach (or copy/paste) all x3 if you file issues for support.
 (Rename `.log` to e.g. `log.txt` and `client.log.YYYY-MM-DD` to e.g. `client.log.YYYY-MM-DD.json`
 in order to be able to upload as attachment to GitHub issues.)
 
+The Bazel and JDT Job status is not in these log files, but visible
+on the _Terminal_ view _Bazel Build Status_ and _Java Build Status_ tabs;
+if in doubt, have a look at that as well.
+
 ## Extensions
 
 Please note that this _Bazel for Java_ extension (`sfdc.bazel-vscode-java`, which adds support for Bazel's **Java** rules to VSC), is technically completely independent of _[the VSC Bazel](https://marketplace.visualstudio.com/items?itemName=BazelBuild.vscode-bazel)_ extension (`BazelBuild.vscode-bazel`, which adds generic support for Bazel `BUILD` files editing, and "externally running" any Bazel targets; but specific nothing for Java).

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -40,8 +40,6 @@ see [issue #94](https://github.com/salesforce/bazel-vscode-java/issues/94).
 1. Close (all of) your VSC windows
 1. `killall java` (check that `jps` only shows _Jps_ itself)
 1. `cd YOURPROJECT`
-1. `rm -rf bazel-*` removes all Bazel related temporary files of course; but this should almost never be required!
-1. `rm -rf .eclipse/` removes all files configuring this extension, this normally also isn't required, but just in case
 1. `bazel build //...` must first work, obviously (double check!)
 1. `code .`
 1. Double check that the [the extension](vscode:extension/sfdc.bazel-vscode-java) is installed **and not disabled**


### PR DESCRIPTION
I just had it "not work" again...

... and this is a bunch of things I tried.

No cleaning helped, and then I did an update of the extension (thus the uninstall/reinstall tip), and it worked again.

Which seems very weird, given that there don't seem to be any major changes recently.

The menus were there, the extension was "activated" according to VSC, but it just didn't configure the project.

@guw