### PR TITLE
remove project basedir from file watcher exclusion pattern

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import path, { join } from 'path';
+import { join } from 'path';
 import { format } from 'util';
 import {
 	ConfigurationTarget,
@@ -69,7 +69,7 @@ export async function activate(context: ExtensionContext) {
 		'isBazelWorkspaceRoot',
 		isBazelWorkspaceRoot()
 	);
-	// create .eclipse/.bazelproject file is DNE
+	// create .eclipse/.bazelproject file if DNE
 	if (isBazelWorkspaceRoot()) {
 		initBazelProjectFile();
 		const showBazelprojectConfig =
@@ -271,10 +271,9 @@ async function syncProjectViewDirectories() {
 						(k) => k.includes('.vscode') && k.includes('.eclipse')
 					).length;
 
-					const baseFolder = getWorkspaceRoot().split(path.sep).reverse()[0];
 					const fileWatcherExcludePattern = viewAll
 						? ''
-						: `**/${baseFolder}/!(${Array.from(displayFolders).join('|')})/**`;
+						: `**/!(${Array.from(displayFolders).join('|')})/**`;
 
 					if (viewAll) {
 						// if viewAll and existing config doesn't contain .vscode/.eclipse return


### PR DESCRIPTION
there is an issue with the exiting filewatcher exclusion pattern where when the TS language server starts up the number of file handles can go extremely large (depending of the size of the project). This change fixes that issue