### PR TITLE
added support for buildifier auto-formating on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,13 +57,34 @@
 			{
 				"id": "bazelproject",
 				"aliases": [
-					"bazelproject",
 					"bazelproject"
 				],
 				"extensions": [
 					".bazelproject"
 				],
 				"configuration": "./syntaxes/bazelproject-language-configuration.json"
+			},
+			{
+				"id": "starlark",
+				"aliases": [
+					"Starlark",
+					"starlark",
+					"Bazel"
+				],
+				"extensions": [
+					".BUILD",
+					".WORKSPACE",
+					".bazel",
+					".bzl",
+					".bzlmod",
+					".sky",
+					".star"
+				],
+				"filenames": [
+					"BUILD",
+					"WORKSPACE"
+				],
+				"configuration": "./syntaxes/starlark-language-configuration.json"
 			}
 		],
 		"grammars": [
@@ -71,6 +92,11 @@
 				"language": "bazelproject",
 				"scopeName": "source.bazelproject",
 				"path": "./syntaxes/bazelproject.tmLanguage.json"
+			},
+			{
+				"language": "starlark",
+				"scopeName": "source.starlark",
+				"path": "./syntaxes/starlark.tmLanguage.json"
 			}
 		],
 		"taskDefinitions": [
@@ -130,6 +156,18 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Display 'sync project view' notification info window on .bazelproject edit",
+					"scope": "window"
+				},
+				"bazel.buildifier.enable": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable buildifier formatting tool on save",
+					"scope": "window"
+				},
+				"bazel.buildifier.binary": {
+					"type": ["string", "null"],
+					"default": null,
+					"description": "path to buildifier binary. If not set buildifier from your PATH will be used",
 					"scope": "window"
 				}
 			}
@@ -270,7 +308,7 @@
 		"esbuild:watch": "npm run esbuild:base -- --sourcemap --watch",
 		"analyze": "npm run esbuild:base -- --minify --metafile --analyze && esbuild-visualizer --metadata ./meta.json --open",
 		"lint": "eslint src --ext ts",
-		"lint:fix" : "eslint src --ext ts --fix",
+		"lint:fix": "eslint src --ext ts --fix",
 		"test": "run-s clean test:*",
 		"test:compile": "tsc -b ./test/tsconfig.json",
 		"test:lint": "eslint --ext .js,.ts,.tsx src",

--- a/src/buildifier.ts
+++ b/src/buildifier.ts
@@ -1,0 +1,99 @@
+import { exec } from 'child_process';
+import {
+	languages,
+	Range,
+	TextDocument,
+	TextEdit,
+	window,
+	workspace,
+} from 'vscode';
+import { getWorkspaceRoot } from './util';
+
+export function registerBuildifierFormatter() {
+	languages.registerDocumentFormattingEditProvider(
+		{ scheme: 'file', language: 'starlark' },
+		{
+			async provideDocumentFormattingEdits(
+				document: TextDocument
+			): Promise<TextEdit[]> {
+				if (
+					workspace.getConfiguration('bazel.buildifier').get('enable', false)
+				) {
+					try {
+						if (await buildifierExists()) {
+							const updatedContent = await runBuildifier(document.fileName);
+
+							// only return an edit if there is a value in `updatedContent`
+							return !!updatedContent
+								? [
+										TextEdit.replace(
+											new Range(
+												0,
+												0,
+												document.lineCount - 1,
+												document.lineAt(
+													document.lineCount - 1
+												).rangeIncludingLineBreak.end.character
+											),
+											updatedContent
+										),
+									]
+								: [];
+						}
+					} catch (err) {
+						window.showErrorMessage(`${err}`);
+						return [];
+					}
+				}
+
+				return [];
+			},
+		}
+	);
+}
+
+function buildifierExists(): Promise<boolean> {
+	return new Promise((resolve, reject) => {
+		exec(
+			`${getBuildifierCmd()} -version`,
+			{ cwd: getWorkspaceRoot() },
+			(err, stdout, stderr) => {
+				if (err) {
+					return reject(err);
+				}
+				return resolve(!stderr);
+			}
+		);
+	});
+}
+
+/**
+ * Utility function used to fetch the formatted text from the `buildifier`
+ * cmd. Uses `exec` since we want to get all of the cmd response in a single
+ * text blob
+ * @param bazelFile
+ * @returns
+ */
+function runBuildifier(bazelFile: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		exec(
+			`${getBuildifierCmd()} -mode print_if_changed ${workspace.asRelativePath(bazelFile)}`,
+			{
+				cwd: getWorkspaceRoot(),
+			},
+			(err, stdout, stderr) => {
+				if (err) {
+					console.error(stderr);
+					return reject(err);
+				}
+				return resolve(stdout);
+			}
+		);
+	});
+}
+
+function getBuildifierCmd(): string {
+	return workspace.getConfiguration('bazel.buildifier').get('binary')
+		? workspace.getConfiguration('bazel.buildifier').get('binary', 'buildifier')
+		: 'buildifier';
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
 	getBazelTerminal,
 } from './bazelLangaugeServerTerminal';
 import { BazelTaskManager } from './bazelTaskManager';
+import { registerBuildifierFormatter } from './buildifier';
 import { Commands, executeJavaLanguageServerCommand } from './commands';
 import { registerLSClient } from './loggingTCPServer';
 import { ProjectViewManager } from './projectViewManager';
@@ -27,7 +28,6 @@ import {
 } from './util';
 
 const workspaceRoot = getWorkspaceRoot();
-const workspaceRootName = workspaceRoot.split('/').reverse()[0];
 
 export async function activate(context: ExtensionContext) {
 	// activates
@@ -123,6 +123,8 @@ export async function activate(context: ExtensionContext) {
 			ProjectViewManager.covertToMultiRoot
 		)
 	);
+
+	registerBuildifierFormatter();
 
 	// trigger a refresh of the tree view when any task get executed
 	tasks.onDidStartTask((_) => BazelRunTargetProvider.instance.refresh());

--- a/syntaxes/starlark-language-configuration.json
+++ b/syntaxes/starlark-language-configuration.json
@@ -1,0 +1,32 @@
+{
+    "comments": {
+        "lineComment": "#"
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        {
+            "open": "\"",
+            "close": "\"",
+            "notIn": ["string", "comment"]
+        },
+        {
+            "open": "'",
+            "close": "'",
+            "notIn": ["string", "comment"]
+        }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -1,0 +1,928 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Starlark",
+	"scopeName": "source.starlark",
+	"fileTypes": ["BUILD", "WORKSPACE", "bazel", "bzl", "sky", "star"],
+	"patterns": [
+		{
+			"include": "#statement"
+		},
+		{
+			"include": "#expression"
+		}
+	],
+	"repository": {
+		"statement": {
+			"patterns": [
+				{
+					"include": "#function-definition"
+				},
+				{
+					"include": "#statement-keyword"
+				},
+				{
+					"include": "#assignment-operator"
+				},
+				{
+					"include": "#docstring-statement"
+				},
+				{
+					"include": "#discouraged-semicolon"
+				}
+			]
+		},
+		"docstring-statement": {
+			"begin": "^(?=\\s*r?('''|\"\"\"|'|\"))",
+			"end": "(?<='''|\"\"\"|'|\")",
+			"patterns": [
+				{
+					"include": "#docstring"
+				}
+			]
+		},
+		"docstring": {
+			"patterns": [
+				{
+					"name": "comment.block.documentation.python.starlark",
+					"begin": "('''|\"\"\")",
+					"end": "(\\1)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.python.starlark"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python.starlark"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code-tag"
+						},
+						{
+							"include": "#docstring-content"
+						}
+					]
+				},
+				{
+					"name": "comment.block.documentation.python.starlark",
+					"begin": "(r)('''|\"\"\")",
+					"end": "(\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.string.python.starlark"
+						},
+						"2": {
+							"name": "punctuation.definition.string.begin.python.starlark"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python.starlark"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#string-consume-escape"
+						},
+						{
+							"include": "#code-tag"
+						}
+					]
+				},
+				{
+					"name": "comment.line.documentation.python.starlark",
+					"begin": "('|\")",
+					"end": "(\\1)|((?<!\\\\)\\n)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.python.starlark"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python.starlark"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python.starlark"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code-tag"
+						},
+						{
+							"include": "#docstring-content"
+						}
+					]
+				},
+				{
+					"name": "comment.line.documentation.python.starlark",
+					"begin": "(r)('|\")",
+					"end": "(\\2)|((?<!\\\\)\\n)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.string.python.starlark"
+						},
+						"2": {
+							"name": "punctuation.definition.string.begin.python.starlark"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python.starlark"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python.starlark"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#string-consume-escape"
+						},
+						{
+							"include": "#code-tag"
+						}
+					]
+				}
+			]
+		},
+		"docstring-content": {
+			"patterns": [
+				{
+					"include": "#string-escape-sequence"
+				},
+				{
+					"include": "#discouraged-string-line-continuation"
+				}
+			]
+		},
+		"statement-keyword": {
+			"patterns": [
+				{
+					"name": "storage.type.function.python.starlark",
+					"match": "\\b(\\s*def)\\b"
+				},
+				{
+					"name": "keyword.control.flow.python.starlark",
+					"match": "\\b(?<!\\.)(break|continue|elif|else|for|if|pass|return)\\b"
+				},
+				{
+					"name": "invalid.illegal.keyword.python.starlark",
+					"match": "\\b(?<!\\.)(as|assert|class|del|except|finally|from|global|import|is|lambda|nonlocal|raise|try|while|with|yield)\\b"
+				}
+			]
+		},
+		"expression-base": {
+			"patterns": [
+				{
+					"include": "#line-comment"
+				},
+				{
+					"include": "#literal"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#illegal-operator"
+				},
+				{
+					"include": "#operator"
+				},
+				{
+					"include": "#dictionary-literal"
+				},
+				{
+					"include": "#subscript-expression"
+				},
+				{
+					"include": "#list-literal"
+				},
+				{
+					"include": "#parenthesized-expression"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#builtin-function"
+				},
+				{
+					"include": "#constant-identifier"
+				},
+				{
+					"include": "#type-identifier"
+				},
+				{
+					"include": "#illegal-name"
+				},
+				{
+					"include": "#line-continuation"
+				}
+			]
+		},
+		"expression": {
+			"patterns": [
+				{
+					"include": "#expression-base"
+				},
+				{
+					"include": "#member-access"
+				},
+				{
+					"include": "#variable"
+				}
+			]
+		},
+		"variable": {
+			"match": "\\b([[:alpha:]_]\\w*)\\b",
+			"name": "variable.other.python.starlark"
+		},
+		"member-access": {
+			"begin": "(\\.)\\s*(?!\\.)",
+			"end": "(?# Stop when we read non-whitespace followed by non-word; i.e. when finished reading an identifier or function call)(?<=\\S)(?=\\W)|(?# Stop when seeing the start of something that's not a word; e.g., a non-identifier)(^|(?<=\\s))(?=[^\\\\\\w\\s])|$",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.accessor.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#member-access-base"
+				},
+				{
+					"include": "#member-access-property"
+				}
+			]
+		},
+		"member-access-base": {
+			"patterns": [
+				{
+					"include": "#illegal-name"
+				},
+				{
+					"include": "#builtin-constant"
+				},
+				{
+					"include": "#constant-identifier"
+				},
+				{
+					"include": "#type-identifier"
+				},
+				{
+					"include": "#line-continuation"
+				},
+				{
+					"include": "#subscript-expression"
+				}
+			]
+		},
+		"member-access-property": {
+			"match": "\\b([[:alpha:]_]\\w*)\\b",
+			"name": "variable.other.property.python.starlark"
+		},
+		"constant-identifier": {
+			"name": "variable.other.constant.python.starlark",
+			"match": "\\b_*[[:upper:]][[:upper:]\\d]*(_\\w*)?\\b"
+		},
+		"type-identifier": {
+			"name": "entity.name.type.python.starlark",
+			"match": "\\b_*[[:upper:]][[:alpha:]\\d]*(_\\w*)?\\b"
+		},
+		"dictionary-literal": {
+			"comment": "This also currently covers comprehensions.",
+			"begin": "\\{",
+			"end": "\\}",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.dict.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.dict.end.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"list-literal": {
+			"comment": "This also currently covers comprehensions.",
+			"begin": "\\[",
+			"end": "\\]",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.list.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.list.end.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"parenthesized-expression": {
+			"comment": "This covers tuples and parenthesized expressions.",
+			"begin": "\\(",
+			"end": "\\)",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.parenthesis.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.parenthesis.end.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"line-continuation": {
+			"patterns": [
+				{
+					"match": "(\\\\)\\s*(\\S.*$\\n?)",
+					"captures": {
+						"1": {
+							"name": "invalid.deprecated.continuation.line.python.starlark"
+						},
+						"2": {
+							"name": "invalid.illegal.line.continuation.python.starlark"
+						}
+					}
+				},
+				{
+					"begin": "(\\\\)\\s*$\\n?",
+					"end": "(?=^\\s*$)|(?!(\\s*[rR]?('''|\"\"\"|'|\"))|(\\G$))",
+					"beginCaptures": {
+						"1": {
+							"name": "invalid.deprecated.continuation.line.python.starlark"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#string"
+						}
+					]
+				}
+			]
+		},
+		"assignment-operator": {
+			"name": "keyword.operator.assignment.python.starlark",
+			"match": "//=|\\+=|-=|/=|\\*=|%=|=(?!=)"
+		},
+		"operator": {
+			"match": "\\b(?<!\\.)(?:(and|or|not|in)(?# 1)|(for|if|else)(?# 2))(?!\\s*:)\\b|(\\*|\\+|-|%|//|/)(?# 3)|(!=|==|>=|<=|<|>)(?# 4)",
+			"captures": {
+				"1": {
+					"name": "keyword.operator.logical.python.starlark"
+				},
+				"2": {
+					"name": "keyword.control.flow.python.starlark"
+				},
+				"3": {
+					"name": "keyword.operator.arithmetic.python.starlark"
+				},
+				"4": {
+					"name": "keyword.operator.comparison.python.starlark"
+				}
+			}
+		},
+		"literal": {
+			"patterns": [
+				{
+					"name": "constant.language.python.starlark",
+					"match": "\\b(True|False|None)\\b"
+				},
+				{
+					"include": "#number"
+				}
+			]
+		},
+		"number": {
+			"patterns": [
+				{
+					"include": "#number-decimal"
+				},
+				{
+					"include": "#number-hexadecimal"
+				},
+				{
+					"include": "#number-octal"
+				},
+				{
+					"name": "invalid.illegal.name.python.starlark",
+					"match": "\\b[0-9]+\\w+"
+				}
+			]
+		},
+		"number-decimal": {
+			"name": "constant.numeric.decimal.python.starlark",
+			"match": "(?<![\\w\\.])(?:[1-9][0-9]*|0+)\\b"
+		},
+		"number-hexadecimal": {
+			"name": "constant.numeric.hex.python.starlark",
+			"match": "(?<![\\w\\.])0[xX][0-9a-fA-F]+\\b"
+		},
+		"number-octal": {
+			"name": "constant.numeric.octal.python.starlark",
+			"match": "(?<![\\w\\.])0[oO][0-7]+\\b"
+		},
+		"string": {
+			"patterns": [
+				{
+					"include": "#string-raw-quoted-multi-line"
+				},
+				{
+					"include": "#string-raw-quoted-single-line"
+				},
+				{
+					"include": "#string-quoted-multi-line"
+				},
+				{
+					"include": "#string-quoted-single-line"
+				}
+			]
+		},
+		"string-raw-quoted-single-line": {
+			"name": "string.quoted.raw.single.python.starlark",
+			"begin": "\\b(r)(['\"])",
+			"end": "(\\2)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.string.python.starlark"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python.starlark"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-raw-content"
+				}
+			]
+		},
+		"string-quoted-single-line": {
+			"name": "string.quoted.single.python.starlark",
+			"begin": "(['\"])",
+			"end": "(\\1)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python.starlark"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-content"
+				}
+			]
+		},
+		"string-raw-quoted-multi-line": {
+			"name": "string.quoted.raw.multi.python.starlark",
+			"begin": "\\b(r)('''|\"\"\")",
+			"end": "(\\2)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.string.python.starlark"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-raw-content"
+				}
+			]
+		},
+		"string-quoted-multi-line": {
+			"name": "string.quoted.multi.python.starlark",
+			"begin": "('''|\"\"\")",
+			"end": "(\\1)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-content"
+				}
+			]
+		},
+		"string-content": {
+			"patterns": [
+				{
+					"include": "#string-escape-sequence"
+				},
+				{
+					"include": "#string-illegal-escape-sequence"
+				},
+				{
+					"include": "#discouraged-string-line-continuation"
+				},
+				{
+					"include": "#string-format-placeholder-percent"
+				},
+				{
+					"include": "#string-format-placeholder-braces"
+				}
+			]
+		},
+		"string-raw-content": {
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				},
+				{
+					"include": "#string-format-placeholder-percent"
+				},
+				{
+					"include": "#string-format-placeholder-braces"
+				}
+			]
+		},
+		"string-consume-escape": {
+			"match": "\\\\['\"\\n\\\\]"
+		},
+		"string-escape-sequence": {
+			"name": "constant.character.escape.python.starlark",
+			"match": "\\\\[\\\\\"'nrt]"
+		},
+		"string-illegal-escape-sequence": {
+			"name": "invalid.illegal.character.escape.python.starlark",
+			"match": "\\\\[^\\\\\"'nrt]"
+		},
+		"string-format-placeholder-percent": {
+			"name": "constant.character.format.placeholder.other.python.starlark",
+			"match": "%[drs%]"
+		},
+		"string-format-placeholder-braces": {
+			"patterns": [
+				{
+					"name": "constant.character.format.placeholder.other.python.starlark",
+					"match": "\\{(?:[0-9]+|[[:alpha:]_][[:alnum:]_]*)?\\}"
+				}
+			]
+		},
+		"function-definition": {
+			"name": "meta.function.python.starlark",
+			"begin": "\\s*\\b(def)\\s+(?=[[:alpha:]_][[:word:]]*\\s*\\()",
+			"end": "(:|(?=[#'\"\\n]))",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.function.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.function.begin.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-definition-name"
+				},
+				{
+					"include": "#function-definition-parameters"
+				},
+				{
+					"include": "#line-continuation"
+				}
+			]
+		},
+		"function-definition-name": {
+			"patterns": [
+				{
+					"include": "#builtin-constant"
+				},
+				{
+					"include": "#illegal-name"
+				},
+				{
+					"include": "#builtin-function"
+				},
+				{
+					"name": "entity.name.function.python.starlark",
+					"match": "\\b([[:alpha:]_]\\w*)\\b"
+				}
+			]
+		},
+		"function-definition-parameters": {
+			"name": "meta.function.parameters.python.starlark",
+			"begin": "(\\()",
+			"end": "(\\))",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.parameters.begin.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.parameters.end.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"name": "keyword.operator.unpacking.parameter.python.starlark",
+					"match": "(\\*\\*|\\*)"
+				},
+				{
+					"include": "#illegal-name"
+				},
+				{
+					"include": "#builtin-constant"
+				},
+				{
+					"match": "([[:alpha:]_]\\w*)\\s*(?:(,)|(?=[)#\\n=]))",
+					"captures": {
+						"1": {
+							"name": "variable.parameter.python.starlark"
+						},
+						"2": {
+							"name": "punctuation.separator.parameters.python.starlark"
+						}
+					}
+				},
+				{
+					"include": "#line-comment"
+				},
+				{
+					"include": "#function-definition-parameter-default-value"
+				}
+			]
+		},
+		"function-definition-parameter-default-value": {
+			"begin": "(=)",
+			"end": "(,)|(?=\\))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.python.starlark"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.parameters.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"subscript-expression": {
+			"patterns": [
+				{
+					"name": "meta.item-access.python.starlark",
+					"begin": "\\b(?=[[:alpha:]_]\\w*\\s*\\[)",
+					"end": "(\\])",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.arguments.end.python.starlark"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#subscript-receiver"
+						},
+						{
+							"include": "#subscript-index"
+						},
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
+		"subscript-receiver": {
+			"patterns": [
+				{
+					"include": "#builtin-function"
+				},
+				{
+					"include": "#constant-identifier"
+				},
+				{
+					"name": "variable.other.python.starlark",
+					"match": "\\b([[:alpha:]_]\\w*)\\b"
+				}
+			]
+		},
+		"subscript-index": {
+			"begin": "(\\[)",
+			"end": "(?=\\])",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.begin.python.starlark"
+				}
+			},
+			"contentName": "meta.item-access.arguments.starlark",
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"function-call": {
+			"name": "meta.function-call.python.starlark",
+			"begin": "\\b(?=([[:alpha:]_]\\w*)\\s*(\\())",
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.end.python.starlark"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call-name"
+				},
+				{
+					"include": "#function-arguments"
+				}
+			]
+		},
+		"function-call-name": {
+			"patterns": [
+				{
+					"include": "#type-identifier"
+				},
+				{
+					"include": "#builtin-function"
+				},
+				{
+					"name": "entity.name.function.python.starlark",
+					"match": "\\b([[:alpha:]_]\\w*)\\b"
+				}
+			]
+		},
+		"function-arguments": {
+			"begin": "(?:(\\()(?:\\s*(\\*\\*|\\*))?)",
+			"end": "(?=\\))(?!\\)\\s*\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.begin.python.starlark"
+				},
+				"2": {
+					"name": "keyword.operator.unpacking.arguments.python.starlark"
+				}
+			},
+			"contentName": "meta.function-call.arguments.starlark",
+			"patterns": [
+				{
+					"match": "(?:(,)(?:\\s*(\\*\\*|\\*))?)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.arguments.python.starlark"
+						},
+						"2": {
+							"name": "keyword.operator.unpacking.arguments.python.starlark"
+						}
+					}
+				},
+				{
+					"include": "#illegal-name"
+				},
+				{
+					"match": "\\b([[:alpha:]_]\\w*)\\s*(=)(?!=)",
+					"captures": {
+						"1": {
+							"name": "meta.parameter.keyword.python.starlark"
+						},
+						"2": {
+							"name": "keyword.operator.assignment.python.starlark"
+						}
+					}
+				},
+				{
+					"name": "keyword.operator.assignment.python.starlark",
+					"match": "=(?!=)"
+				},
+				{
+					"include": "#expression"
+				},
+				{
+					"match": "\\s*(\\))\\s*(\\()",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.arguments.end.python.starlark"
+						},
+						"2": {
+							"name": "punctuation.definition.arguments.begin.python.starlark"
+						}
+					}
+				}
+			]
+		},
+		"builtin-function": {
+			"patterns": [
+				{
+					"name": "support.function.python.starlark",
+					"match": "(?<!\\.)\\b(all|any|bool|dict|dir|enumerate|getattr|hasattr|hash|int|len|list|load|max|min|print|range|repr|reversed|sorted|str|tuple|type|zip)\\b"
+				}
+			]
+		},
+		"builtin-constant": {
+			"name": "keyword.illegal.name.python.starlark",
+			"match": "\\b(True|False|None)\\b"
+		},
+		"illegal-name": {
+			"name": "keyword.control.flow.python.starlark",
+			"match": "\\b(and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|load|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
+		},
+		"illegal-operator": {
+			"patterns": [
+				{
+					"name": "invalid.illegal.operator.python.starlark",
+					"match": "&&|\\|\\||--|\\+\\+"
+				},
+				{
+					"name": "invalid.illegal.operator.python.starlark",
+					"match": "[?$]"
+				},
+				{
+					"name": "invalid.illegal.operator.python.starlark",
+					"match": "!\\b"
+				}
+			]
+		},
+		"line-comment": {
+			"name": "comment.line.number-sign.python.starlark",
+			"begin": "(\\#)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.python.starlark"
+				}
+			},
+			"end": "($)",
+			"patterns": [
+				{
+					"include": "#code-tag"
+				}
+			]
+		},
+		"code-tag": {
+			"match": "(?:\\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\\b)",
+			"captures": {
+				"1": {
+					"name": "keyword.codetag.notation.python.starlark"
+				}
+			}
+		},
+		"discouraged-semicolon": {
+			"patterns": [
+				{
+					"name": "invalid.deprecated.semicolon.python.starlark",
+					"match": "\\;$"
+				}
+			]
+		},
+		"discouraged-string-line-continuation": {
+			"name": "invalid.deprecated.language.python.starlark",
+			"match": "\\\\$"
+		}
+	}
+}

--- a/test/projects/small/.buildifier-tables.json
+++ b/test/projects/small/.buildifier-tables.json
@@ -1,0 +1,24 @@
+{
+  "documentation for humans": {
+    "What": "This file explains to buildifier how to sort format custom attributes.",
+    "See": "https://github.com/bazelbuild/buildtools/blob/master/tables/tables.go"
+  },
+  "IsLabelArg": {},
+  "LabelDenylist": {},
+  "IsSortableListArg": {
+      "dependencies": true,
+      "runtime_dependencies": true,
+      "junit_package_prefix_pref": false
+  },
+  "SortableAllowlist": {},
+  "NamePriority": {
+      "type": -10,
+      "dependencies": 10,
+      "notes": 12,
+      "runtime_dependencies": 15,
+      "additional_resources": 20,
+      "source_generators": 30,
+      "junit_package_prefix_pref": 39,
+      "testdata": 40
+  }
+}

--- a/test/projects/small/.buildifier.json
+++ b/test/projects/small/.buildifier.json
@@ -1,0 +1,7 @@
+{
+  "documentation for humans": {
+    "What": "This file provides buildifier configuration.",
+    "See": "https://github.com/bazelbuild/buildtools/blob/master/buildifier/config/config.go"
+  },
+  "addTables": ".buildifier-tables.json"
+}

--- a/test/projects/small/.vscode/settings.json
+++ b/test/projects/small/.vscode/settings.json
@@ -17,15 +17,24 @@
 		"bazel-small": false,
 		"bazel-testlogs": false,
 		".settings": true,
-		"tools": false
+		"tools": false,
+		"bin": false
 	},
 	"java.bazel.log.level": "trace",
 	"java.showBuildStatusOnStart.enabled": "terminal",
 	"java.debug.logLevel": "verbose",
 	"java.trace.server": "verbose",
 	"java.server.launchMode": "Standard",
-	"java.transport":"stdio",
-	"java.import.generatesMetadataFilesAtProjectRoot":false,
+	"java.transport": "stdio",
+	"java.import.generatesMetadataFilesAtProjectRoot": false,
 	"java.autobuild.enabled": true,
-	"bazel.projectview.open": false
+	"bazel.projectview.open": false,
+	"files.watcherExclude": {
+		"**/.git/objects/**": true,
+		"**/.git/subtree-cache/**": true,
+		"**/node_modules/*/**": true,
+		"**/.hg/store/**": true
+	},
+	"editor.formatOnSave": true,
+	"bazel.buildifier.enable": true
 }


### PR DESCRIPTION
Added the following:

 - starlark syntax and language config file (needed for language detection)
 - added buildifier `format on save` feature; this is gated behind a couple of flags
     - `editor.formatOnSave`
     - `bazel.buildifier.enable`
 - both flags must be `true` to enable this feature (follows best practices laid out [here](https://code.visualstudio.com/blogs/2016/11/15/formatters-best-practices))