### PR TITLE
expose a public API methods from this extension

### DIFF
--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -1,0 +1,5 @@
+import { BazelProjectView } from './types';
+
+export interface BazelVscodeExtensionAPI {
+	readonly parseProjectFile: BazelProjectView;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,9 +14,11 @@ import {
 	BazelLanguageServerTerminal,
 	getBazelTerminal,
 } from './bazelLangaugeServerTerminal';
+import { getBazelProjectFile } from './bazelprojectparser';
 import { BazelTaskManager } from './bazelTaskManager';
 import { registerBuildifierFormatter } from './buildifier';
 import { Commands, executeJavaLanguageServerCommand } from './commands';
+import { BazelVscodeExtensionAPI } from './extension.api';
 import { registerLSClient } from './loggingTCPServer';
 import { ProjectViewManager } from './projectViewManager';
 import { BazelRunTargetProvider } from './provider/bazelRunTargetProvider';
@@ -29,7 +31,9 @@ import {
 
 const workspaceRoot = getWorkspaceRoot();
 
-export async function activate(context: ExtensionContext) {
+export async function activate(
+	context: ExtensionContext
+): Promise<BazelVscodeExtensionAPI> {
 	// activates
 	// LS processes current .eclipse/.bazelproject file
 	// if it DNE create one
@@ -137,9 +141,13 @@ export async function activate(context: ExtensionContext) {
 
 	// always update the project view after the initial project load
 	registerLSClient();
+
+	return Promise.resolve({
+		parseProjectFile: await getBazelProjectFile(),
+	});
 }
 
-export function deactivate() { }
+export function deactivate() {}
 
 function syncProjectView(): void {
 	if (!isRedhatJavaReady()) {

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -2,10 +2,24 @@ import * as assert from 'assert';
 import { setTimeout } from 'node:timers/promises';
 import { env } from 'process';
 import * as vscode from 'vscode';
+import { extensions } from 'vscode';
 import { Commands } from '../../src/commands';
+import { BazelVscodeExtensionAPI } from '../../src/extension.api';
 import { Jdtls } from './Jdtls';
 
 suite('Java Language Extension - Standard', () => {
+	suiteSetup(async function () {
+		await extensions.getExtension('sfdc.bazel-vscode-java')?.activate();
+	});
+
+	test('version should be correct', async function () {
+		const api: BazelVscodeExtensionAPI = extensions.getExtension(
+			'sfdc.bazel-vscode-java'
+		)?.exports;
+
+		assert.ok(api.parseProjectFile !== null);
+	});
+
 	test('RedHat Java Extension should be present', () => {
 		assert.ok(vscode.extensions.getExtension('redhat.java'));
 	});


### PR DESCRIPTION
- this plugin now returns an `ExtensionAPI` object with (currently) a single method that parses the project `.bazelproject` and returns a `BazelProjectView` object.
- this is to allow other dependent extensions the ability to get the current state of the bazel project view without having to duplicate our parsing code
- Added a test to validate the public methods returns some value