### PR TITLE
node version bump for 'publish' action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node version
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: 'npm'
 
       - name: 📦 Install dependencies


### PR DESCRIPTION
missed this during the last PR