### PR TITLE
add otel

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -8,72 +8,77 @@ import esbuild from 'esbuild';
 
 const isWatchMode = process.argv.includes('--watch');
 const options: BuildOptions = {
-    color: true,
-    logLevel: 'info',
-    entryPoints: ['src/extension.ts'],
-    bundle: true,
-    metafile: process.argv.includes('--metafile'),
-    outdir: './out/src',
-    external: [
-        'vscode',
-        'typescript', // vue-component-meta
-    ],
-    format: 'cjs',
-    platform: 'node',
-    target: 'ESNext',
-    tsconfig: 'src/tsconfig.json',
-    sourcemap: process.argv.includes('--sourcemap'),
-    minify: process.argv.includes('--minify'),
-    plugins: [
-        {
-            name: 'umd2esm',
-            setup(build) {
-                build.onResolve({ filter: /^(vscode-.*|estree-walker|jsonc-parser)/ }, (args) => {
-                    const pathUmdMay = require.resolve(args.path, {
-                        paths: [args.resolveDir],
-                    });
-                    // Call twice the replace is to solve the problem of the path in Windows
-                    const pathEsm = pathUmdMay
-                        .replace('/umd/', '/esm/')
-                        .replace('\\umd\\', '\\esm\\');
-                    return { path: pathEsm };
-                });
-            },
-        },
-        {
-            name: 'meta',
-            setup(build) {
-                build.onEnd(async (result) => {
-                    if (result.metafile && result.errors.length === 0) {
-                        return fs.writeFile(
-                            path.resolve(__dirname, './meta.json'),
-                            JSON.stringify(result.metafile),
-                        );
-                    }
-                });
-            },
-        },
-    ],
+	color: true,
+	logLevel: 'info',
+	entryPoints: ['src/extension.ts'],
+	bundle: true,
+	metafile: process.argv.includes('--metafile'),
+	outdir: './out/src',
+	external: [
+		'vscode',
+		'typescript', // vue-component-meta
+	],
+	format: 'cjs',
+	platform: 'node',
+	target: 'ESNext',
+	tsconfig: 'src/tsconfig.json',
+	sourcemap: process.argv.includes('--sourcemap'),
+	minify: process.argv.includes('--minify'),
+	plugins: [
+		{
+			name: 'umd2esm',
+			setup(build) {
+				build.onResolve(
+					{ filter: /^(vscode-.*|estree-walker|jsonc-parser)/ },
+					(args) => {
+						const pathUmdMay = require.resolve(args.path, {
+							paths: [args.resolveDir],
+						});
+						// Call twice the replace is to solve the problem of the path in Windows
+						const pathEsm = pathUmdMay
+							.replace('/umd/', '/esm/')
+							.replace('\\umd\\', '\\esm\\');
+						return { path: pathEsm };
+					}
+				);
+			},
+		},
+		{
+			name: 'meta',
+			setup(build) {
+				build.onEnd(async (result) => {
+					if (result.metafile && result.errors.length === 0) {
+						return fs.writeFile(
+							path.resolve(__dirname, './meta.json'),
+							JSON.stringify(result.metafile)
+						);
+					}
+				});
+			},
+		},
+	],
 };
 
 async function main() {
-    let ctx: BuildContext | undefined;
-    try {
-        if (isWatchMode) {
-            ctx = await esbuild.context(options);
-            await ctx.watch();
-        } else {
-            const result = await esbuild.build(options);
+	let ctx: BuildContext | undefined;
+	try {
+		if (isWatchMode) {
+			ctx = await esbuild.context(options);
+			await ctx.watch();
+		} else {
+			const result = await esbuild.build(options);
 			if (process.argv.includes('--analyze')) {
-				const chunksTree = await esbuild.analyzeMetafile(result.metafile!, { color: true });
-                console.log(chunksTree);
-            }
-        }
-    } catch (error) {
-        console.error(error);
-        ctx?.dispose();
-        process.exit(1);
-    }
+				const chunksTree = await esbuild.analyzeMetafile(result.metafile!, {
+					color: true,
+				});
+				console.log(chunksTree);
+			}
+		}
+	} catch (error) {
+		console.error(error);
+		ctx?.dispose();
+		process.exit(1);
+	}
 }
 
 main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,21 @@
 {
 	"name": "bazel-vscode-java",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bazel-vscode-java",
-			"version": "1.4.1",
+			"version": "1.4.2",
 			"license": "BSD-3-Clause",
 			"dependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/exporter-metrics-otlp-proto": "^0.203.0",
+				"@opentelemetry/exporter-trace-otlp-proto": "^0.203.0",
+				"@opentelemetry/resources": "^2.0.1",
+				"@opentelemetry/sdk-metrics": "^2.0.1",
+				"@opentelemetry/sdk-trace-web": "^2.0.1",
+				"@opentelemetry/semantic-conventions": "^1.36.0",
 				"fast-xml-parser": "^4.4.1"
 			},
 			"devDependencies": {
@@ -20,7 +27,7 @@
 				"@typescript-eslint/parser": "^6.0.0",
 				"@vscode/test-cli": "^0.0.10",
 				"@vscode/test-electron": "^2.4.1",
-				"@vscode/vsce": "^3.2.1",
+				"@vscode/vsce": "^3.6.0",
 				"esbuild": "0.19.8",
 				"esbuild-plugin-eslint": "^0.3.7",
 				"esbuild-visualizer": "^0.4.1",
@@ -54,6 +61,23 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@azu/format-text": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+			"integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@azu/style-format": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+			"integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+			"dev": true,
+			"license": "WTFPL",
+			"dependencies": {
+				"@azu/format-text": "^1.0.1"
 			}
 		},
 		"node_modules/@azure/abort-controller": {
@@ -287,6 +311,31 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {
@@ -891,6 +940,228 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/api-logs": {
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+			"integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/core": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+			"integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.203.0.tgz",
+			"integrity": "sha512-HFSW10y8lY6BTZecGNpV3GpoSy7eaO0Z6GATwZasnT4bEsILp8UJXNG5OmEsz4SdwCSYvyCbTJdNbZP3/8LGCQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-metrics": "2.0.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.203.0.tgz",
+			"integrity": "sha512-OZnhyd9npU7QbyuHXFEPVm3LnjZYifuKpT3kTnF84mXeEQ84pJJZgyLBpU4FSkSwUkt/zbMyNAI7y5+jYTWGIg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/exporter-metrics-otlp-http": "0.203.0",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-metrics": "2.0.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.203.0.tgz",
+			"integrity": "sha512-1xwNTJ86L0aJmWRwENCJlH4LULMG2sOXWIVw+Szta4fkqKVY50Eo4HoVKKq6U9QEytrWCr8+zjw0q/ZOeXpcAQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-exporter-base": {
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.203.0.tgz",
+			"integrity": "sha512-Wbxf7k+87KyvxFr5D7uOiSq/vHXWommvdnNE7vECO3tAhsA2GfOlpWINCMWUEPdHZ7tCXxw6Epp3vgx3jU7llQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-transformer": "0.203.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer": {
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.203.0.tgz",
+			"integrity": "sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.203.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-logs": "0.203.0",
+				"@opentelemetry/sdk-metrics": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1",
+				"protobufjs": "^7.3.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
+			"integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-logs": {
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.203.0.tgz",
+			"integrity": "sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.203.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.4.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
+			"integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.9.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+			"integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-web": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.1.tgz",
+			"integrity": "sha512-R4/i0rISvAujG4Zwk3s6ySyrWG+Db3SerZVM4jZ2lEzjrNylF7nRAy1hVvWe8gTbwIxX+6w6ZvZwdtl2C7UQHQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.36.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
+			"integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -911,6 +1182,618 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@secretlint/config-creator": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+			"integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/types": "^10.2.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/config-loader": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+			"integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/profiler": "^10.2.2",
+				"@secretlint/resolver": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"ajv": "^8.17.1",
+				"debug": "^4.4.1",
+				"rc-config-loader": "^4.1.3"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/config-loader/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@secretlint/config-loader/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@secretlint/config-loader/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/config-loader/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/core": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+			"integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/profiler": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"debug": "^4.4.1",
+				"structured-source": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/core/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@secretlint/core/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/formatter": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+			"integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/resolver": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"@textlint/linter-formatter": "^15.2.0",
+				"@textlint/module-interop": "^15.2.0",
+				"@textlint/types": "^15.2.0",
+				"chalk": "^5.4.1",
+				"debug": "^4.4.1",
+				"pluralize": "^8.0.0",
+				"strip-ansi": "^7.1.0",
+				"table": "^6.9.0",
+				"terminal-link": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/formatter/node_modules/ansi-regex": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+			"integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@secretlint/formatter/node_modules/chalk": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
+			"integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@secretlint/formatter/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@secretlint/formatter/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/formatter/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@secretlint/node": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+			"integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/config-loader": "^10.2.2",
+				"@secretlint/core": "^10.2.2",
+				"@secretlint/formatter": "^10.2.2",
+				"@secretlint/profiler": "^10.2.2",
+				"@secretlint/source-creator": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"debug": "^4.4.1",
+				"p-map": "^7.0.3"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/node/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@secretlint/node/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/profiler": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+			"integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/resolver": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+			"integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/secretlint-formatter-sarif": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+			"integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-sarif-builder": "^3.2.0"
+			}
+		},
+		"node_modules/@secretlint/secretlint-rule-no-dotenv": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+			"integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/types": "^10.2.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/secretlint-rule-preset-recommend": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+			"integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/source-creator": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+			"integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/types": "^10.2.2",
+				"istextorbinary": "^9.5.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/types": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+			"integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@textlint/ast-node-types": {
+			"version": "15.2.2",
+			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.2.2.tgz",
+			"integrity": "sha512-9ByYNzWV8tpz6BFaRzeRzIov8dkbSZu9q7IWqEIfmRuLWb2qbI/5gTvKcoWT1HYs4XM7IZ8TKSXcuPvMb6eorA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/linter-formatter": {
+			"version": "15.2.2",
+			"resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.2.2.tgz",
+			"integrity": "sha512-oMVaMJ3exFvXhCj3AqmCbLaeYrTNLqaJnLJMIlmnRM3/kZdxvku4OYdaDzgtlI194cVxamOY5AbHBBVnY79kEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@azu/format-text": "^1.0.2",
+				"@azu/style-format": "^1.0.1",
+				"@textlint/module-interop": "15.2.2",
+				"@textlint/resolver": "15.2.2",
+				"@textlint/types": "15.2.2",
+				"chalk": "^4.1.2",
+				"debug": "^4.4.1",
+				"js-yaml": "^3.14.1",
+				"lodash": "^4.17.21",
+				"pluralize": "^2.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"table": "^6.9.0",
+				"text-table": "^0.2.0"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+			"integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@textlint/module-interop": {
+			"version": "15.2.2",
+			"resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.2.2.tgz",
+			"integrity": "sha512-2rmNcWrcqhuR84Iio1WRzlc4tEoOMHd6T7urjtKNNefpTt1owrTJ9WuOe60yD3FrTW0J/R0ux5wxUbP/eaeFOA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/resolver": {
+			"version": "15.2.2",
+			"resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.2.2.tgz",
+			"integrity": "sha512-4hGWjmHt0y+5NAkoYZ8FvEkj8Mez9TqfbTm3BPjoV32cIfEixl2poTOgapn1rfm73905GSO3P1jiWjmgvii13Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/types": {
+			"version": "15.2.2",
+			"resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.2.2.tgz",
+			"integrity": "sha512-X2BHGAR3yXJsCAjwYEDBIk9qUDWcH4pW61ISfmtejau+tVqKtnbbvEZnMTb6mWgKU1BvTmftd5DmB1XVDUtY3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@textlint/ast-node-types": "15.2.2"
 			}
 		},
 		"node_modules/@types/glob": {
@@ -952,10 +1835,23 @@
 			"version": "20.11.19",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
 			"integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
-			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
+		},
+		"node_modules/@types/normalize-package-data": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/sarif": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+			"integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.7",
@@ -1277,19 +2173,23 @@
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.2.1.tgz",
-			"integrity": "sha512-AY9vBjwExakK1c0cI/3NN2Ey0EgiKLBye/fxl/ue+o4q6RZ7N+xzd1jAD6eI6eBeMVANi617+V2rxIAkDPco2Q==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.6.0.tgz",
+			"integrity": "sha512-u2ZoMfymRNJb14aHNawnXJtXHLXDVKc1oKZaH4VELKT/9iWKRVgtQOdwxCgtwSxJoqYvuK4hGlBWQJ05wxADhg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@azure/identity": "^4.1.0",
+				"@secretlint/node": "^10.1.1",
+				"@secretlint/secretlint-formatter-sarif": "^10.1.1",
+				"@secretlint/secretlint-rule-no-dotenv": "^10.1.1",
+				"@secretlint/secretlint-rule-preset-recommend": "^10.1.1",
 				"@vscode/vsce-sign": "^2.0.0",
 				"azure-devops-node-api": "^12.5.0",
-				"chalk": "^2.4.2",
+				"chalk": "^4.1.2",
 				"cheerio": "^1.0.0-rc.9",
 				"cockatiel": "^3.1.2",
-				"commander": "^6.2.1",
+				"commander": "^12.1.0",
 				"form-data": "^4.0.0",
 				"glob": "^11.0.0",
 				"hosted-git-info": "^4.0.2",
@@ -1300,6 +2200,7 @@
 				"minimatch": "^3.0.3",
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
+				"secretlint": "^10.1.1",
 				"semver": "^7.5.2",
 				"tmp": "^0.2.3",
 				"typed-rest-client": "^1.8.4",
@@ -1463,6 +2364,22 @@
 				"win32"
 			]
 		},
+		"node_modules/@vscode/vsce/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1472,6 +2389,43 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
+		},
+		"node_modules/@vscode/vsce/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@vscode/vsce/node_modules/form-data": {
 			"version": "4.0.0",
@@ -1528,6 +2482,16 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/@vscode/vsce/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@vscode/vsce/node_modules/jackspeak": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
@@ -1574,11 +2538,25 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+		"node_modules/@vscode/vsce/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1631,6 +2609,22 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+			"integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"environment": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-gray": {
@@ -1839,6 +2833,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/async-done": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/async-done/-/async-done-2.0.0.tgz",
@@ -1992,6 +2996,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/binaryextensions": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+			"integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"editions": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
 		"node_modules/bl": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -2007,6 +3027,13 @@
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"dev": true
+		},
+		"node_modules/boundary": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+			"integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -2471,12 +3498,13 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">= 6"
+				"node": ">=18"
 			}
 		},
 		"node_modules/concat-map": {
@@ -2980,6 +4008,23 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/editions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+			"integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"version-range": "^4.15.0"
+			},
+			"engines": {
+				"ecmascript": ">= es5",
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -3019,6 +4064,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/environment": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/error-ex": {
@@ -3445,6 +4503,20 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/esquery": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -3568,16 +4640,17 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.4"
+				"micromatch": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=8.6.0"
@@ -3606,6 +4679,23 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-parser": {
 			"version": "4.4.1",
@@ -3882,6 +4972,21 @@
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+			"integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
 		},
 		"node_modules/fs-mkdirp-stream": {
 			"version": "2.0.1",
@@ -5013,6 +6118,19 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/index-to-position": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+			"integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5577,6 +6695,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/istextorbinary": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+			"integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"binaryextensions": "^6.11.0",
+				"editions": "^6.21.0",
+				"textextensions": "^6.11.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
 		"node_modules/jackspeak": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
@@ -5594,6 +6730,13 @@
 			"optionalDependencies": {
 				"@pkgjs/parseargs": "^0.11.0"
 			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -5649,11 +6792,37 @@
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true
 		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"node_modules/jsonwebtoken": {
 			"version": "9.0.2",
@@ -5888,6 +7057,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lodash._basecopy": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -6062,6 +7238,13 @@
 				"lodash.escape": "^3.0.0"
 			}
 		},
+		"node_modules/lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -6147,6 +7330,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -6234,12 +7423,13 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -6707,6 +7897,20 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/node-sarif-builder": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
+			"integrity": "sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/sarif": "^2.1.7",
+				"fs-extra": "^11.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -7150,6 +8354,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+			"integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -7363,6 +8580,13 @@
 			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
 			"dev": true
 		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -7469,6 +8693,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -7537,6 +8771,30 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
+			"integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/psl": {
 			"version": "1.9.0",
@@ -7632,6 +8890,19 @@
 			},
 			"bin": {
 				"rc": "cli.js"
+			}
+		},
+		"node_modules/rc-config-loader": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
+			"integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.2",
+				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/rc/node_modules/strip-json-comments": {
@@ -7817,6 +9088,16 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8011,6 +9292,209 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
 			"integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
 			"dev": true
+		},
+		"node_modules/secretlint": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+			"integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/config-creator": "^10.2.2",
+				"@secretlint/formatter": "^10.2.2",
+				"@secretlint/node": "^10.2.2",
+				"@secretlint/profiler": "^10.2.2",
+				"debug": "^4.4.1",
+				"globby": "^14.1.0",
+				"read-pkg": "^9.0.1"
+			},
+			"bin": {
+				"secretlint": "bin/secretlint.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/secretlint/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/secretlint/node_modules/globby": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.3",
+				"ignore": "^7.0.3",
+				"path-type": "^6.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/secretlint/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/secretlint/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/secretlint/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/secretlint/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/secretlint/node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/secretlint/node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/secretlint/node_modules/path-type": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/secretlint/node_modules/read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/secretlint/node_modules/read-pkg/node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/secretlint/node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/secretlint/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/seek-bzip": {
 			"version": "1.0.6",
@@ -8220,6 +9704,60 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/sparkles": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
@@ -8260,6 +9798,13 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
 			"integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
 			"dev": true
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/sshpk": {
 			"version": "1.18.0",
@@ -8616,6 +10161,16 @@
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
+		"node_modules/structured-source": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+			"integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boundary": "^2.0.0"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -8626,6 +10181,46 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/supports-hyperlinks": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+			}
+		},
+		"node_modules/supports-hyperlinks/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-hyperlinks/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -8673,6 +10268,69 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/table": {
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/table/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/table/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/table/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/table/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tapable": {
@@ -8769,6 +10427,23 @@
 				"streamx": "^2.12.5"
 			}
 		},
+		"node_modules/terminal-link": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+			"integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.0.0",
+				"supports-hyperlinks": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -8820,6 +10495,22 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
+		},
+		"node_modules/textextensions": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+			"integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"editions": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
 		},
 		"node_modules/throttleit": {
 			"version": "1.0.1",
@@ -9614,8 +11305,30 @@
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -9710,6 +11423,19 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"dev": true
+		},
+		"node_modules/version-range": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+			"integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
 		},
 		"node_modules/vinyl": {
 			"version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -172,6 +172,24 @@
 					"default": null,
 					"description": "path to buildifier binary. If not set buildifier from your PATH will be used",
 					"scope": "window"
+				},
+				"bazel.telemetry.endpoint": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "OTEL endpoint to send telemetry",
+					"scope": "window"
+				},
+				"bazel.telemetry.headers": {
+					"type": [
+						"object",
+						"null"
+					],
+					"default": null,
+					"description": "OTEL headers",
+					"scope": "window"
 				}
 			}
 		},
@@ -332,7 +350,7 @@
 		"@typescript-eslint/parser": "^6.0.0",
 		"@vscode/test-cli": "^0.0.10",
 		"@vscode/test-electron": "^2.4.1",
-		"@vscode/vsce": "^3.2.1",
+		"@vscode/vsce": "^3.6.0",
 		"esbuild": "0.19.8",
 		"esbuild-plugin-eslint": "^0.3.7",
 		"esbuild-visualizer": "^0.4.1",
@@ -356,6 +374,13 @@
 		"vscode-languageclient": "^9.0.1"
 	},
 	"dependencies": {
+		"@opentelemetry/api": "^1.9.0",
+		"@opentelemetry/exporter-metrics-otlp-proto": "^0.203.0",
+		"@opentelemetry/exporter-trace-otlp-proto": "^0.203.0",
+		"@opentelemetry/resources": "^2.0.1",
+		"@opentelemetry/sdk-metrics": "^2.0.1",
+		"@opentelemetry/sdk-trace-web": "^2.0.1",
+		"@opentelemetry/semantic-conventions": "^1.36.0",
 		"fast-xml-parser": "^4.4.1"
 	}
 }

--- a/src/tracing/otelUtils.ts
+++ b/src/tracing/otelUtils.ts
@@ -1,0 +1,170 @@
+import opentelemetry, { Counter, Meter, Tracer } from '@opentelemetry/api';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+import {
+	defaultResource,
+	Resource,
+	resourceFromAttributes,
+} from '@opentelemetry/resources';
+import {
+	ConsoleMetricExporter,
+	MeterProvider,
+	PeriodicExportingMetricReader,
+	PushMetricExporter,
+} from '@opentelemetry/sdk-metrics';
+import {
+	BatchSpanProcessor,
+	ConsoleSpanExporter,
+	SpanExporter,
+	WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
+import {
+	ATTR_SERVICE_NAME,
+	ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions';
+import {
+	ExtensionContext,
+	TextDocument,
+	workspace,
+	WorkspaceConfiguration,
+} from 'vscode';
+
+interface Headers {
+	[key: string]: string;
+}
+
+const DEFAULT_ENDPOINT = 'http://localhost:4318';
+const DEFAULT_HEADERS = {} as Headers;
+
+export class ExtensionOtel {
+	private static _instance: ExtensionOtel;
+	private _config: WorkspaceConfiguration;
+	private _context: ExtensionContext;
+	private _resource: Resource;
+	private _traceExporter: SpanExporter;
+	private _metricExporter: PushMetricExporter;
+	private _traceProvider: WebTracerProvider;
+	private _meterProvider: MeterProvider;
+	private _tracer: Tracer;
+	private _meter: Meter;
+	private _fileOpenCounter: Counter;
+	private _fileSaveCounter: Counter;
+
+	private constructor(ctx: ExtensionContext) {
+		this._context = ctx;
+		this._config = workspace.getConfiguration('bazel.telemetry');
+		this._resource = defaultResource().merge(
+			resourceFromAttributes({
+				[ATTR_SERVICE_NAME]: ctx.extension.packageJSON.name,
+				[ATTR_SERVICE_VERSION]: ctx.extension.packageJSON.version,
+			})
+		);
+		this._traceExporter = new OTLPTraceExporter({
+			url: `${this.endpoint}/v1/traces`,
+			headers: this.headers,
+		});
+		this._metricExporter = new OTLPMetricExporter({
+			url: `${this.endpoint}/v1/metrics`,
+			headers: this.headers,
+		});
+
+		this._traceProvider = new WebTracerProvider({
+			resource: this._resource,
+			spanProcessors: [
+				new BatchSpanProcessor(this._traceExporter),
+				new BatchSpanProcessor(new ConsoleSpanExporter()),
+			],
+		});
+		this._traceProvider.register();
+
+		this._meterProvider = new MeterProvider({
+			resource: this._resource,
+			readers: [
+				new PeriodicExportingMetricReader({
+					exporter: this._metricExporter,
+				}),
+				new PeriodicExportingMetricReader({
+					exporter: new ConsoleMetricExporter(),
+				}),
+			],
+		});
+
+		opentelemetry.metrics.setGlobalMeterProvider(this._meterProvider);
+
+		this._tracer = opentelemetry.trace.getTracer(
+			ctx.extension.packageJSON.name
+		);
+		this._meter = opentelemetry.metrics.getMeter(
+			ctx.extension.packageJSON.name
+		);
+
+		this._fileOpenCounter = this._meter.createCounter('file.opened', {
+			unit: 'lang',
+		});
+		this._fileSaveCounter = this._meter.createCounter('file.saved', {
+			unit: 'lang',
+		});
+	}
+
+	private get endpoint() {
+		if (this._config.get('endpoint')) {
+			return this._config.get<string>('endpoint', DEFAULT_ENDPOINT);
+		}
+		return process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+			? process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+			: DEFAULT_ENDPOINT;
+	}
+
+	private get headers() {
+		if (this._config.get('headers')) {
+			return this._config.get<Headers>('headers', DEFAULT_HEADERS);
+		}
+
+		return process.env.OTEL_EXPORTER_OTLP_HEADERS
+			? process.env.OTEL_EXPORTER_OTLP_HEADERS.trim()
+					.split(',')
+					.reduce((acc, val) => {
+						const [k, v] = val.split('=');
+						acc[k.trim()] = v.trim();
+						return acc;
+					}, DEFAULT_HEADERS)
+			: DEFAULT_HEADERS;
+	}
+
+	public static getInstance(ctx: ExtensionContext): ExtensionOtel {
+		if (!this._instance) {
+			this._instance = new ExtensionOtel(ctx);
+		}
+		return this._instance;
+	}
+
+	public get tracer(): Tracer {
+		return this._tracer;
+	}
+
+	public get meter(): Meter {
+		return this._meter;
+	}
+
+	public get fileOpenCounter() {
+		return this._fileOpenCounter;
+	}
+
+	public get fileSaveCounter() {
+		return this._fileSaveCounter;
+	}
+}
+
+export function registerMetrics(context: ExtensionContext) {
+	workspace.onDidOpenTextDocument((e: TextDocument) => {
+		ExtensionOtel.getInstance(context).fileOpenCounter.add(1, {
+			lang: e.languageId,
+		});
+	});
+
+	workspace.onDidSaveTextDocument((e: TextDocument) => {
+		ExtensionOtel.getInstance(context).fileSaveCounter.add(1, {
+			lang: e.languageId,
+		});
+	});
+}

--- a/test/suite/Jdtls.ts
+++ b/test/suite/Jdtls.ts
@@ -2,22 +2,26 @@
 // Licensed under the MIT license.
 // copied from https://github.com/jdneo/vscode-java-dependency/blob/86e7b60e8dd17a7bcaf0c39fe9dbcd5e8cf236d9/src/java/jdtls.ts
 
-import { Commands, executeJavaExtensionCommand, executeJavaLanguageServerCommand } from "../../src/commands";
-import { UpdateClasspathResponse } from "../../src/types";
+import {
+	Commands,
+	executeJavaExtensionCommand,
+	executeJavaLanguageServerCommand,
+} from '../../src/commands';
+import { UpdateClasspathResponse } from '../../src/types';
 
 export namespace Jdtls {
-    export function getSourcePaths(): Thenable<UpdateClasspathResponse> {
-        return executeJavaLanguageServerCommand(Commands.JAVA_LS_LIST_SOURCEPATHS);
-    }
+	export function getSourcePaths(): Thenable<UpdateClasspathResponse> {
+		return executeJavaLanguageServerCommand(Commands.JAVA_LS_LIST_SOURCEPATHS);
+	}
 
-    export function buildWorkspace(): Thenable<CompileWorkspaceStatus> {
-        return executeJavaExtensionCommand(Commands.JAVA_BUILD_WORKSPACE, false);
-    }
+	export function buildWorkspace(): Thenable<CompileWorkspaceStatus> {
+		return executeJavaExtensionCommand(Commands.JAVA_BUILD_WORKSPACE, false);
+	}
 
-    export enum CompileWorkspaceStatus {
-        Failed = 0,
-        Succeed = 1,
-        Witherror = 2,
-        Cancelled = 3,
-    }
+	export enum CompileWorkspaceStatus {
+		Failed = 0,
+		Succeed = 1,
+		Witherror = 2,
+		Cancelled = 3,
+	}
 }

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -9,7 +9,11 @@ import { Jdtls } from './Jdtls';
 
 suite('Java Language Extension - Standard', () => {
 	suiteSetup(async function () {
-		await extensions.getExtension('sfdc.bazel-vscode-java')?.activate();
+		try {
+			await extensions.getExtension('sfdc.bazel-vscode-java')?.activate();
+		} catch (e) {
+			console.error(e);
+		}
 	});
 
 	test('version should be correct', async function () {
@@ -114,10 +118,15 @@ suite('Java Language Extension - Standard', () => {
 		return Jdtls.buildWorkspace().then((result) => {
 			assert.strictEqual(result, Jdtls.CompileWorkspaceStatus.Succeed);
 
-			return Jdtls.getSourcePaths().then((resp) => {
-				const projects = new Set(resp.data.map((p) => p.projectName));
-				assert.ok(projects.size > 0);
-			});
+			return Jdtls.getSourcePaths().then(
+				(resp) => {
+					const projects = new Set(resp.data.map((p) => p.projectName));
+					assert.ok(projects.size > 0);
+				},
+				(e) => {
+					console.error(JSON.stringify(e));
+				}
+			);
 		});
 	});
 });


### PR DESCRIPTION
Add generic OTEL implementation that can be configured to direct telemetry to a configurable endpoint. Default is `http://localhost:4318`

Mostly interested in what types of files developers are interacting with to help drive new features for this extension